### PR TITLE
Adds rm to the compose feature set

### DIFF
--- a/charms/docker/compose.py
+++ b/charms/docker/compose.py
@@ -55,9 +55,9 @@ class Compose:
         defined `docker-compose.yml`
         '''
         if service:
-            cmd = "docker-compose rm {}".format(service)
+            cmd = "docker-compose rm -f {}".format(service)
         else:
-            cmd = "docker-compose rm"
+            cmd = "docker-compose rm -f"
         self.run(cmd)
 
     def run(self, cmd):

--- a/charms/docker/compose.py
+++ b/charms/docker/compose.py
@@ -47,6 +47,19 @@ class Compose:
             cmd = "docker-compose kill"
         self.run(cmd)
 
+    def rm(self, service=None):
+        '''
+        Convenience method that wraps `docker-compose rm`
+
+        usage: c.rm('nginx') to remove the 'nginx' service from the
+        defined `docker-compose.yml`
+        '''
+        if service:
+            cmd = "docker-compose rm {}".format(service)
+        else:
+            cmd = "docker-compose rm"
+        self.run(cmd)
+
     def run(self, cmd):
         '''
         chdir sets working context on the workspace

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name = "charms.docker",
-    version = "0.0.4",
+    version = "0.0.5",
     author = "Charles Butler",
     author_email = "charles.butler@ubuntu.com",
     url = "http://github.com/juju-solutions/charms.docker",

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -48,13 +48,13 @@ class TestCompose:
     def test_rm_service_default(self, compose):
         with patch('charms.docker.compose.Compose.run') as s:
             compose.rm()
-            expect = 'docker-compose rm'
+            expect = 'docker-compose rm -f'
             s.assert_called_with(expect)
 
     def test_rm_service(self, compose):
         with patch('charms.docker.compose.Compose.run') as s:
             compose.rm('nginx')
-            expect = 'docker-compose rm nginx'
+            expect = 'docker-compose rm -f nginx'
             s.assert_called_with(expect)
 
     @patch('charms.docker.compose.chdir')

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -39,10 +39,22 @@ class TestCompose:
             expect = 'docker-compose kill nginx'
             s.assert_called_with(expect)
 
-    def test_kill_service(self, compose):
+    def test_kill_service_default(self, compose):
         with patch('charms.docker.compose.Compose.run') as s:
             compose.kill()
             expect = 'docker-compose kill'
+            s.assert_called_with(expect)
+
+    def test_rm_service_default(self, compose):
+        with patch('charms.docker.compose.Compose.run') as s:
+            compose.rm()
+            expect = 'docker-compose rm'
+            s.assert_called_with(expect)
+
+    def test_rm_service(self, compose):
+        with patch('charms.docker.compose.Compose.run') as s:
+            compose.rm('nginx')
+            expect = 'docker-compose rm nginx'
             s.assert_called_with(expect)
 
     @patch('charms.docker.compose.chdir')


### PR DESCRIPTION
usage:

```
c = Compose('path/to/workspace')
c.rm('nginx')  will remove the nginx container
c.rm() will remove all containers in the docker-compose file
```
