### PR TITLE
Adds `pop` method to DockerOptsManager

### DIFF
--- a/charms/docker/dockeropts.py
+++ b/charms/docker/dockeropts.py
@@ -62,6 +62,21 @@ class DockerOpts:
             self.data[key] = None
         self.__save()
 
+    def pop(self, key):
+        '''
+        Completely remove a flag from the DockerOpts manager including any
+        associated values. Assuming the data is currently:
+        {'foo': ['bar', 'baz']}
+
+        d.pop('foo')
+        > {}
+
+        :params key:
+        '''
+
+        self.data.pop(key)
+        self.__save()
+    
     def remove(self, key, value):
         '''
         Remove a flag value from the DockerOpts manager

--- a/tests/test_dockeropts.py
+++ b/tests/test_dockeropts.py
@@ -31,6 +31,14 @@ class TestDockerOpts:
         assert 'baz' not in d.data['foo']
         assert 'bar' in d.data['foo']
 
+    def test_pop_key(self):
+        d = DockerOpts()
+        d.add('temporary', 'test-flag-pop')
+        # assert the data made it before we attempt popping it off the dict
+        assert 'test-flag-pop' in d.data['temporary']
+        d.pop('temporary')
+        assert 'temporary' not in d.data
+
     def test_data_persistence(self):
         x = DockerOpts()
         x.add('juju', 'is amazing')


### PR DESCRIPTION
This allows end consumers to wholesale pop a config flag off the
dictionary thats backing the DockerOpts values. This is useful when the
end user wishes to remove both a key and a value.
