### PR TITLE
Strip trailing newline from Docker/Compose output

### DIFF
--- a/charms/docker/docker.py
+++ b/charms/docker/docker.py
@@ -194,6 +194,7 @@ class Docker:
             cmd = "docker {}".format(cmd)
 
         try:
-            return subprocess.check_output(split(cmd)).decode('ascii')
+            output = subprocess.check_output(split(cmd)).decode('ascii')
+            return output.rstrip('\n')
         except subprocess.CalledProcessError as expect:
             return "Error: {0} returned: {1}".format(cmd, expect.returncode)

--- a/charms/docker/runner.py
+++ b/charms/docker/runner.py
@@ -22,7 +22,7 @@ def run(cmd, workspace, socket=None):
             out = check_output(split(cmd))
         else:
             out = check_output(split(cmd))
-        return out
+        return out.rstrip('\n')
 
 
 # This is helpful for setting working directory context


### PR DESCRIPTION
Not sure how it passed me by when testing the last commit, but comparing with the output is easier if the trailing newline is stripped. :)

I'll move it to `healthcheck()` if you don't want to strip it from every call.