### PR TITLE
Decode Compose output

### DIFF
--- a/charms/docker/runner.py
+++ b/charms/docker/runner.py
@@ -22,7 +22,7 @@ def run(cmd, workspace, socket=None):
             out = check_output(split(cmd))
         else:
             out = check_output(split(cmd))
-        return out.rstrip('\n')
+        return out.decode('ascii').rstrip('\n')
 
 
 # This is helpful for setting working directory context


### PR DESCRIPTION
The output of Docker Compose wasn't decoded so an `rstrip()` on the bytes would fail.

The mocks in the test returned a string as output, that's why it passed. My bad for not testing it for real. 