### PR TITLE
Wraps the down command of docker-compose so I can use it...

### DIFF
--- a/charms/docker/compose.py
+++ b/charms/docker/compose.py
@@ -138,3 +138,15 @@ class Compose:
         else:
             cmd = "docker-compose up -d"
         run(cmd, self.workspace, self.socket)
+
+    def down(self, service=None):
+        '''
+        Convenience method that wraps `docker-compose down`
+
+        :param service: if defined only stops the specified service
+        '''
+        if service:
+            cmd = "docker-compose down {}".format(service)
+        else:
+            cmd = "docker-compose down"
+        run(cmd, self.workspace, self.socket)

--- a/charms/docker/compose.py
+++ b/charms/docker/compose.py
@@ -139,14 +139,9 @@ class Compose:
             cmd = "docker-compose up -d"
         run(cmd, self.workspace, self.socket)
 
-    def down(self, service=None):
+    def down(self):
         '''
         Convenience method that wraps `docker-compose down`
-
-        :param service: if defined only stops the specified service
         '''
-        if service:
-            cmd = "docker-compose down {}".format(service)
-        else:
-            cmd = "docker-compose down"
+        cmd = "docker-compose down"
         run(cmd, self.workspace, self.socket)

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -90,6 +90,20 @@ class TestCompose:
             expect = 'docker-compose up -d'
             s.assert_called_with(expect, compose.workspace, None)
 
+    def test_down_service(self, compose):
+        with patch('charms.docker.compose.run') as s:
+            compose.up('nginx')
+            compose.down('nginx')
+            expect = 'docker-compose down nginx'
+            s.assert_called_with(expect, compose.workspace, None)
+
+    def test_down_default_formation(self, compose):
+        with patch('charms.docker.compose.run') as s:
+            compose.up()
+            compose.down()
+            expect = 'docker-compose down'
+            s.assert_called_with(expect, compose.workspace, None)
+
     def test_start_service(self, compose):
         with patch('charms.docker.compose.run') as s:
             compose.start('nginx')

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -90,13 +90,6 @@ class TestCompose:
             expect = 'docker-compose up -d'
             s.assert_called_with(expect, compose.workspace, None)
 
-    def test_down_service(self, compose):
-        with patch('charms.docker.compose.run') as s:
-            compose.up('nginx')
-            compose.down('nginx')
-            expect = 'docker-compose down nginx'
-            s.assert_called_with(expect, compose.workspace, None)
-
     def test_down_default_formation(self, compose):
         with patch('charms.docker.compose.run') as s:
             compose.up()


### PR DESCRIPTION
…in my docker-registry charm (when attaching storage to and requiring everything to be down properly).