### PR TITLE
Bump for 0.1.18

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,7 @@ author = u'Charles Butler'
 # built documents.
 #
 # The short X.Y version.
-version = u'0.1.17'
+version = u'0.1.18'
 # The full version, including alpha/beta/rc tags.
 release = u'0.1.17'
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "charms.docker",
-    version = '0.1.17',
+    version = '0.1.18',
     author = "Charles Butler",
     author_email = "charles.butler@ubuntu.com",
     url = "http://github.com/juju-solutions/charms.docker",


### PR DESCRIPTION
@tvansteenburgh @Cynerva @wwwtyro  This just bumps the meta files. Once this is merged and a tag is pushed, the travis builders will do the release.

Simon contributed a .rmi method to docker-compose module in #40  for removing images. I didn't want to bump the lib until you guys had had a chance to talk about the release and shifting libs underneath your work.

If you're still fine with me managing this repo i'll keep doing the releases as features/fixes come in.

🎩  🍻  